### PR TITLE
Fix installation script for a non-standard Konsole data directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,8 +102,13 @@ trap "printf '${_ctb_error}User aborted.${_ctb_reset}\n' && exit 1" SIGINT SIGTE
 NORD_KONSOLE_SCRIPT_OPTS=`getopt -o vhs: --long verbose,help,schemefile: -n 'install.sh' -- "$@"`
 SCHEME_FILE=src/nord.colorscheme
 VERBOSE=false
-LOCAL_INSTALL_DIR=~/.local/share/konsole
 NORD_KONSOLE_VERSION=0.1.0
+
+if [ -z "$XDG_DATA_HOME" ]; then
+  LOCAL_INSTALL_DIR=~/.local/share/konsole
+else
+  LOCAL_INSTALL_DIR="${XDG_DATA_HOME}/konsole"
+fi
 
 eval set -- "$NORD_KONSOLE_SCRIPT_OPTS"
 while true; do


### PR DESCRIPTION
If Konsole is using a non-standard data directory set with $XDG_DATA_HOME, the install script will detect that and install the theme in the correct directory.

Fixes https://github.com/arcticicestudio/nord-konsole/issues/10